### PR TITLE
some adjustments to make devrel close to working on my machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ BASEDIR = $(shell pwd)
 REBAR = ./rebar3
 RELPATH = _build/default/rel/unir
 PRODRELPATH = _build/prod/rel/unir
+DEV1RELPATH = _build/dev1/rel/unir
+DEV2RELPATH = _build/dev2/rel/unir
+DEV3RELPATH = _build/dev3/rel/unir
 APPNAME = unir
 SHELL = /bin/bash
 CONCURRENCY 	 ?= 4
@@ -219,12 +222,21 @@ test: kill release
 
 devrel1:
 	$(REBAR) as dev1 release
+	mkdir -p $(DEV1RELPATH)/../unir_config
+	[ -f $(DEV1RELPATH)/../unir_config/unir.conf ] || cp $(DEV1RELPATH)/etc/unir.conf  $(DEV1RELPATH)/../unir_config/unir.conf
+	[ -f $(DEV1RELPATH)/../unir_config/advanced.config ] || cp $(DEV1RELPATH)/etc/advanced.config  $(DEV1RELPATH)/../unir_config/advanced.config
 
 devrel2:
 	$(REBAR) as dev2 release
+	mkdir -p $(DEV2RELPATH)/../unir_config
+	[ -f $(DEV2RELPATH)/../unir_config/unir.conf ] || cp $(DEV2RELPATH)/etc/unir.conf  $(DEV2RELPATH)/../unir_config/unir.conf
+	[ -f $(DEV2RELPATH)/../unir_config/advanced.config ] || cp $(DEV2RELPATH)/etc/advanced.config  $(DEV2RELPATH)/../unir_config/advanced.config
 
 devrel3:
 	$(REBAR) as dev3 release
+	mkdir -p $(DEV3RELPATH)/../unir_config
+	[ -f $(DEV3RELPATH)/../unir_config/unir.conf ] || cp $(DEV3RELPATH)/etc/unir.conf  $(DEV3RELPATH)/../unir_config/unir.conf
+	[ -f $(DEV3RELPATH)/../unir_config/advanced.config ] || cp $(DEV3RELPATH)/etc/advanced.config  $(DEV3RELPATH)/../unir_config/advanced.config
 
 devrel: devrel1 devrel2 devrel3
 

--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,7 @@
     {pbkdf2, {git, "git://github.com/marianoguerra/erlang-pbkdf2-no-history", {branch, "master"}}},
     {exometer_core, {git, "git://github.com/basho/exometer_core.git", {branch, "th/correct-dependencies"}}},
     {riak_core, {git, "git://github.com/lasp-lang/riak_core", {branch, "partisan-support-r21"}}},
+    {cuttlefish, {git,"git://github.com/kyorai/cuttlefish.git", {branch, "develop"}}},
     {riak_core_partisan_utils, {git, "git://github.com/lasp-lang/riak_core_partisan_utils", {branch, "master"}}},
     {partisan, {git, "git://github.com/lasp-lang/partisan", {branch, "master"}}},
     {lasp_bench, {git, "git://github.com/lasp-lang/lasp-bench", {branch, "master"}}},


### PR DESCRIPTION
forced cuttlefish to not call `-smp disable` by introducing an explicit dependency + mimicked the prodrel copying of config in devrel builds.

Not sure if it's the preferred method of contributing, but figured it helped me so might be worth submitting